### PR TITLE
Add interactive matchmaking visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+queue_size.png

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# matchmaking_simulation
+# Matchmaking Simulation
+
+This project demonstrates a simple matchmaking system for an online game.
+Players are queued and matched according to region, ELO rating, level and
+time spent waiting.
+
+## Usage
+
+Run a basic simulation:
+
+```bash
+python matchmaking.py
+```
+
+Generate a visualization of queue size over time (requires matplotlib):
+
+```bash
+python visualize.py
+```
+
+The script will output `queue_size.png` with a plot of the queue length at
+each timestep.
+
+### Interactive Demo
+
+To experiment with different parameters interactively, launch:
+
+```bash
+python interactive.py
+```
+
+A window will open with sliders for the number of steps and player join chance.
+Press **Run** to update the charts showing how many players remain in the queue
+and how many matches are created per region.

--- a/interactive.py
+++ b/interactive.py
@@ -1,0 +1,48 @@
+import matplotlib.pyplot as plt
+from matplotlib.widgets import Slider, Button
+from matchmaking import run_simulation, REGIONS
+
+
+def run_and_update(_=None):
+    steps = int(steps_slider.val)
+    join_chance = join_slider.val
+    _, _, qdist, mdist, match_regions = run_simulation(steps, join_chance)
+
+    for bar, val in zip(queue_bars, qdist):
+        bar.set_height(val)
+    ax_queue.set_ylim(0, max(max(qdist), 1) + 1)
+
+    ax_matches.clear()
+    global match_bars
+    match_bars = ax_matches.bar(match_regions, mdist)
+    ax_matches.set_title("Matches per Region")
+    ax_matches.set_ylim(0, max(max(mdist), 1) + 1)
+    fig.canvas.draw_idle()
+
+# initial simulation
+_, _, qdist, mdist, match_regions = run_simulation()
+
+fig, (ax_queue, ax_matches) = plt.subplots(1, 2, figsize=(10, 4))
+queue_bars = ax_queue.bar(REGIONS, qdist)
+ax_queue.set_title("Players in Queue by Region")
+ax_queue.set_ylim(0, max(max(qdist), 1) + 1)
+
+match_bars = ax_matches.bar(match_regions, mdist)
+ax_matches.set_title("Matches per Region")
+ax_matches.set_ylim(0, max(max(mdist), 1) + 1)
+
+axcolor = 'lightgoldenrodyellow'
+ax_join = plt.axes([0.2, 0.02, 0.65, 0.03], facecolor=axcolor)
+join_slider = Slider(ax_join, 'Join Chance', 0.1, 1.0, valinit=0.5)
+
+ax_steps = plt.axes([0.2, 0.06, 0.65, 0.03], facecolor=axcolor)
+steps_slider = Slider(ax_steps, 'Steps', 50, 200, valinit=100, valfmt='%0.0f')
+
+join_slider.on_changed(run_and_update)
+steps_slider.on_changed(run_and_update)
+
+run_button_ax = plt.axes([0.85, 0.85, 0.1, 0.05])
+run_button = Button(run_button_ax, 'Run')
+run_button.on_clicked(run_and_update)
+
+plt.show()

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -1,0 +1,99 @@
+import random
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Player:
+    id: int
+    region: str
+    elo: int
+    level: int
+    join_time: int
+    matched: bool = field(default=False, compare=False)
+
+
+@dataclass
+class Match:
+    players: List[Player]
+    start_time: int
+    region: str
+
+
+class MatchmakingQueue:
+    def __init__(self):
+        self.queue: List[Player] = []
+        self.matches: List[Match] = []
+
+    def add_player(self, player: Player):
+        self.queue.append(player)
+
+    def step(self, current_time: int):
+        # Sort by join time to give priority to older players
+        self.queue.sort(key=lambda p: p.join_time)
+        matched_ids = set()
+        for i, player in enumerate(self.queue):
+            if player.id in matched_ids:
+                continue
+            for j in range(i + 1, len(self.queue)):
+                candidate = self.queue[j]
+                if candidate.id in matched_ids:
+                    continue
+                if self.can_match(player, candidate, current_time):
+                    matched_ids.add(player.id)
+                    matched_ids.add(candidate.id)
+                    region = player.region if player.region == candidate.region else "Cross"
+                    self.matches.append(Match([player, candidate], current_time, region))
+                    break
+        # Remove matched players from queue
+        self.queue = [p for p in self.queue if p.id not in matched_ids]
+
+    @staticmethod
+    def can_match(p1: Player, p2: Player, current_time: int) -> bool:
+        # Region check with expansion after 30s
+        if p1.region != p2.region:
+            if (current_time - p1.join_time < 30) or (current_time - p2.join_time < 30):
+                return False
+        # Calculate dynamic tolerances based on time waiting
+        t1 = current_time - p1.join_time
+        t2 = current_time - p2.join_time
+        elo_tol = 50 + max(t1, t2) * 5
+        lvl_tol = 2 + max(t1, t2) * 0.1
+        return abs(p1.elo - p2.elo) <= elo_tol and abs(p1.level - p2.level) <= lvl_tol
+
+
+def random_player(pid: int, current_time: int) -> Player:
+    regions = ["NA", "EU", "ASIA"]
+    return Player(
+        id=pid,
+        region=random.choice(regions),
+        elo=random.randint(1000, 2000),
+        level=random.randint(1, 50),
+        join_time=current_time,
+    )
+
+
+REGIONS = ["NA", "EU", "ASIA"]
+
+
+def run_simulation(steps: int = 100, join_chance: float = 0.5):
+    mm = MatchmakingQueue()
+    player_id = 0
+    history = []  # Keep queue sizes for visualization
+    for t in range(steps):
+        if random.random() < join_chance:
+            mm.add_player(random_player(player_id, t))
+            player_id += 1
+        mm.step(t)
+        history.append(len(mm.queue))
+
+    queue_dist = [len([p for p in mm.queue if p.region == r]) for r in REGIONS]
+    match_regions = REGIONS + ["Cross"]
+    match_dist = [len([m for m in mm.matches if m.region == r]) for r in match_regions]
+    return mm, history, queue_dist, match_dist, match_regions
+
+
+if __name__ == "__main__":
+    mm, history, qdist, mdist, _ = run_simulation()
+    print(f"Total matches: {len(mm.matches)}")
+    print("Queue distribution:", dict(zip(REGIONS, qdist)))

--- a/visualize.py
+++ b/visualize.py
@@ -1,0 +1,16 @@
+import matplotlib.pyplot as plt
+from matchmaking import run_simulation
+
+
+if __name__ == "__main__":
+    _, history, _, _, _ = run_simulation(steps=200)
+
+    plt.figure(figsize=(8, 4))
+    plt.plot(history, label="Players in queue")
+    plt.xlabel("Time step")
+    plt.ylabel("Queue size")
+    plt.title("Matchmaking Queue Size Over Time")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig("queue_size.png")
+    print("Saved queue_size.png")


### PR DESCRIPTION
## Summary
- make matchmaking state aware of match region
- expose queue and match distributions from `run_simulation`
- add `interactive.py` with sliders to tweak simulation parameters
- document interactive usage in README
- adjust scripts to new function signature

## Testing
- `python matchmaking.py | head`
- `python visualize.py | head`
- `python -m py_compile matchmaking.py visualize.py interactive.py`


------
https://chatgpt.com/codex/tasks/task_e_686f2ffcba0c832c97dda60b86dd4263