### PR TITLE
Add player retention and build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+queue_size.png
+build/
+dist/
+*.spec

--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ each timestep.
 
 ### Interactive Demo
 
-To experiment with different parameters interactively, launch:
+To see the simulation evolve in real time, launch:
 
 ```bash
 python interactive.py
 ```
 
-A window will open with sliders for the number of steps and player join chance.
-Use the **Stay Chance** slider to control the probability that players queue
-for another match after finishing one. Press **Run** to update the charts
-showing how many players remain in the queue and how many matches are created
-per region.
+A window appears with sliders for join and stay probabilities. Press **Start**
+to begin an animated run of the simulation. The plots update every few hundred
+milliseconds, showing how players move through the queue and how many matches
+are formed per region. Use **Pause** to stop the animation and adjust the
+sliders; press **Start** again to restart with the new settings.
 
 ### Building an Executable
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# matchmaking_simulation
+# Matchmaking Simulation
+
+This project demonstrates a simple matchmaking system for an online game.
+Players are queued and matched according to region, ELO rating, level and
+time spent waiting.
+
+## Usage
+
+Run a basic simulation:
+
+```bash
+python matchmaking.py
+```
+
+Generate a visualization of queue size over time (requires matplotlib):
+
+```bash
+python visualize.py
+```
+
+The script will output `queue_size.png` with a plot of the queue length at
+each timestep.
+
+### Interactive Demo
+
+To experiment with different parameters interactively, launch:
+
+```bash
+python interactive.py
+```
+
+A window will open with sliders for the number of steps and player join chance.
+Use the **Stay Chance** slider to control the probability that players queue
+for another match after finishing one. Press **Run** to update the charts
+showing how many players remain in the queue and how many matches are created
+per region.
+
+### Building an Executable
+
+If you have `pyinstaller` installed you can build a standalone Windows binary:
+
+```bash
+pip install pyinstaller
+pyinstaller --onefile interactive.py
+```
+
+The resulting executable will be placed in the `dist` folder. Cross–compiling
+from Linux may require additional setup.

--- a/interactive.py
+++ b/interactive.py
@@ -1,53 +1,72 @@
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, Button
-from matchmaking import run_simulation, REGIONS
+from matplotlib import animation
+
+from matchmaking import simulation_generator, REGIONS
 
 
-def run_and_update(_=None):
-    steps = int(steps_slider.val)
-    join_chance = join_slider.val
+gen = None
+running = False
+
+
+def start(_=None):
+    global gen, running
+    join = join_slider.val
     stay = stay_slider.val
-    _, _, qdist, mdist, match_regions = run_simulation(steps, join_chance, stay)
+    gen = simulation_generator(join_chance=join, stay_chance=stay)
+    running = True
+    ani.event_source.start()
+
+
+def pause(_=None):
+    global running
+    running = False
+    ani.event_source.stop()
+
+
+def update(_):
+    if not running or gen is None:
+        return queue_bars + match_bars
+
+    t, qdist, mdist, match_regions = next(gen)
 
     for bar, val in zip(queue_bars, qdist):
         bar.set_height(val)
     ax_queue.set_ylim(0, max(max(qdist), 1) + 1)
+    ax_queue.set_title(f"Players in Queue by Region (t={t})")
 
-    ax_matches.clear()
-    global match_bars
-    match_bars = ax_matches.bar(match_regions, mdist)
-    ax_matches.set_title("Matches per Region")
+    if len(match_bars) != len(match_regions):
+        ax_matches.clear()
+        match_bars[:] = ax_matches.bar(match_regions, mdist)
+    else:
+        for bar, val in zip(match_bars, mdist):
+            bar.set_height(val)
     ax_matches.set_ylim(0, max(max(mdist), 1) + 1)
-    fig.canvas.draw_idle()
+    ax_matches.set_title("Matches per Region")
+    return queue_bars + match_bars
 
-# initial simulation
-_, _, qdist, mdist, match_regions = run_simulation()
 
 fig, (ax_queue, ax_matches) = plt.subplots(1, 2, figsize=(10, 4))
-queue_bars = ax_queue.bar(REGIONS, qdist)
-ax_queue.set_title("Players in Queue by Region")
-ax_queue.set_ylim(0, max(max(qdist), 1) + 1)
+queue_bars = ax_queue.bar(REGIONS, [0 for _ in REGIONS])
+match_bars = ax_matches.bar(REGIONS + ["Cross"], [0] * (len(REGIONS) + 1))
+ax_queue.set_ylim(0, 1)
+ax_matches.set_ylim(0, 1)
 
-match_bars = ax_matches.bar(match_regions, mdist)
-ax_matches.set_title("Matches per Region")
-ax_matches.set_ylim(0, max(max(mdist), 1) + 1)
-
-axcolor = 'lightgoldenrodyellow'
+axcolor = "lightgoldenrodyellow"
 ax_join = plt.axes([0.2, 0.02, 0.65, 0.03], facecolor=axcolor)
-join_slider = Slider(ax_join, 'Join Chance', 0.1, 1.0, valinit=0.5)
+join_slider = Slider(ax_join, "Join Chance", 0.1, 1.0, valinit=0.5)
 
-ax_steps = plt.axes([0.2, 0.06, 0.65, 0.03], facecolor=axcolor)
-steps_slider = Slider(ax_steps, 'Steps', 50, 200, valinit=100, valfmt='%0.0f')
+ax_stay = plt.axes([0.2, 0.06, 0.65, 0.03], facecolor=axcolor)
+stay_slider = Slider(ax_stay, "Stay Chance", 0.0, 1.0, valinit=0.5)
 
-ax_stay = plt.axes([0.2, 0.10, 0.65, 0.03], facecolor=axcolor)
-stay_slider = Slider(ax_stay, 'Stay Chance', 0.0, 1.0, valinit=0.5)
+start_ax = plt.axes([0.85, 0.85, 0.1, 0.05])
+start_btn = Button(start_ax, "Start")
+start_btn.on_clicked(start)
 
-join_slider.on_changed(run_and_update)
-steps_slider.on_changed(run_and_update)
-stay_slider.on_changed(run_and_update)
+pause_ax = plt.axes([0.85, 0.78, 0.1, 0.05])
+pause_btn = Button(pause_ax, "Pause")
+pause_btn.on_clicked(pause)
 
-run_button_ax = plt.axes([0.85, 0.85, 0.1, 0.05])
-run_button = Button(run_button_ax, 'Run')
-run_button.on_clicked(run_and_update)
-
+ani = animation.FuncAnimation(fig, update, interval=300, blit=False)
 plt.show()
+

--- a/interactive.py
+++ b/interactive.py
@@ -1,0 +1,53 @@
+import matplotlib.pyplot as plt
+from matplotlib.widgets import Slider, Button
+from matchmaking import run_simulation, REGIONS
+
+
+def run_and_update(_=None):
+    steps = int(steps_slider.val)
+    join_chance = join_slider.val
+    stay = stay_slider.val
+    _, _, qdist, mdist, match_regions = run_simulation(steps, join_chance, stay)
+
+    for bar, val in zip(queue_bars, qdist):
+        bar.set_height(val)
+    ax_queue.set_ylim(0, max(max(qdist), 1) + 1)
+
+    ax_matches.clear()
+    global match_bars
+    match_bars = ax_matches.bar(match_regions, mdist)
+    ax_matches.set_title("Matches per Region")
+    ax_matches.set_ylim(0, max(max(mdist), 1) + 1)
+    fig.canvas.draw_idle()
+
+# initial simulation
+_, _, qdist, mdist, match_regions = run_simulation()
+
+fig, (ax_queue, ax_matches) = plt.subplots(1, 2, figsize=(10, 4))
+queue_bars = ax_queue.bar(REGIONS, qdist)
+ax_queue.set_title("Players in Queue by Region")
+ax_queue.set_ylim(0, max(max(qdist), 1) + 1)
+
+match_bars = ax_matches.bar(match_regions, mdist)
+ax_matches.set_title("Matches per Region")
+ax_matches.set_ylim(0, max(max(mdist), 1) + 1)
+
+axcolor = 'lightgoldenrodyellow'
+ax_join = plt.axes([0.2, 0.02, 0.65, 0.03], facecolor=axcolor)
+join_slider = Slider(ax_join, 'Join Chance', 0.1, 1.0, valinit=0.5)
+
+ax_steps = plt.axes([0.2, 0.06, 0.65, 0.03], facecolor=axcolor)
+steps_slider = Slider(ax_steps, 'Steps', 50, 200, valinit=100, valfmt='%0.0f')
+
+ax_stay = plt.axes([0.2, 0.10, 0.65, 0.03], facecolor=axcolor)
+stay_slider = Slider(ax_stay, 'Stay Chance', 0.0, 1.0, valinit=0.5)
+
+join_slider.on_changed(run_and_update)
+steps_slider.on_changed(run_and_update)
+stay_slider.on_changed(run_and_update)
+
+run_button_ax = plt.axes([0.85, 0.85, 0.1, 0.05])
+run_button = Button(run_button_ax, 'Run')
+run_button.on_clicked(run_and_update)
+
+plt.show()

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -113,6 +113,27 @@ def run_simulation(
     return mm, history, queue_dist, match_dist, match_regions
 
 
+def simulation_generator(
+    join_chance: float = 0.5,
+    stay_chance: float = 0.5,
+    match_duration: int = 5,
+):
+    """Yield queue and match distributions step by step."""
+    mm = MatchmakingQueue()
+    player_id = 0
+    t = 0
+    while True:
+        if random.random() < join_chance:
+            mm.add_player(random_player(player_id, t))
+            player_id += 1
+        mm.step(t, stay_chance=stay_chance, match_duration=match_duration)
+        qdist = [len([p for p in mm.queue if p.region == r]) for r in REGIONS]
+        match_regions = REGIONS + ["Cross"]
+        mdist = [len([m for m in mm.completed_matches if m.region == r]) for r in match_regions]
+        yield t, qdist, mdist, match_regions
+        t += 1
+
+
 if __name__ == "__main__":
     mm, history, qdist, mdist, _ = run_simulation()
     print(f"Total matches: {len(mm.completed_matches)}")

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -1,0 +1,119 @@
+import random
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Player:
+    id: int
+    region: str
+    elo: int
+    level: int
+    join_time: int
+    matched: bool = field(default=False, compare=False)
+
+
+@dataclass
+class Match:
+    players: List[Player]
+    start_time: int
+    region: str
+
+
+class MatchmakingQueue:
+    def __init__(self):
+        self.queue: List[Player] = []
+        self.active_matches: List[Match] = []
+        self.completed_matches: List[Match] = []
+
+    def add_player(self, player: Player):
+        self.queue.append(player)
+
+    def step(self, current_time: int, stay_chance: float = 0.5, match_duration: int = 5):
+        # Finish active matches
+        finished = [m for m in self.active_matches if current_time - m.start_time >= match_duration]
+        self.active_matches = [m for m in self.active_matches if m not in finished]
+        for match in finished:
+            self.completed_matches.append(match)
+            for player in match.players:
+                if random.random() < stay_chance:
+                    player.join_time = current_time
+                    self.queue.append(player)
+
+        # Sort by join time to give priority to older players
+        self.queue.sort(key=lambda p: p.join_time)
+        matched_ids = set()
+        for i, player in enumerate(self.queue):
+            if player.id in matched_ids:
+                continue
+            for j in range(i + 1, len(self.queue)):
+                candidate = self.queue[j]
+                if candidate.id in matched_ids:
+                    continue
+                if self.can_match(player, candidate, current_time):
+                    matched_ids.add(player.id)
+                    matched_ids.add(candidate.id)
+                    region = player.region if player.region == candidate.region else "Cross"
+                    self.active_matches.append(Match([player, candidate], current_time, region))
+                    break
+        # Remove matched players from queue
+        self.queue = [p for p in self.queue if p.id not in matched_ids]
+
+    @staticmethod
+    def can_match(p1: Player, p2: Player, current_time: int) -> bool:
+        # Region check with expansion after 30s
+        if p1.region != p2.region:
+            if (current_time - p1.join_time < 30) or (current_time - p2.join_time < 30):
+                return False
+        # Calculate dynamic tolerances based on time waiting
+        t1 = current_time - p1.join_time
+        t2 = current_time - p2.join_time
+        elo_tol = 50 + max(t1, t2) * 5
+        lvl_tol = 2 + max(t1, t2) * 0.1
+        return abs(p1.elo - p2.elo) <= elo_tol and abs(p1.level - p2.level) <= lvl_tol
+
+
+def random_player(pid: int, current_time: int) -> Player:
+    regions = REGIONS
+    elo = int(random.gauss(1500, 200))
+    elo = max(800, min(2200, elo))
+    level = int(random.gauss(25, 10))
+    level = max(1, min(50, level))
+    return Player(
+        id=pid,
+        region=random.choice(regions),
+        elo=elo,
+        level=level,
+        join_time=current_time,
+    )
+
+
+REGIONS = ["NA", "EU", "ASIA"]
+
+
+def run_simulation(
+    steps: int = 100,
+    join_chance: float = 0.5,
+    stay_chance: float = 0.5,
+    match_duration: int = 5,
+):
+    mm = MatchmakingQueue()
+    player_id = 0
+    history = []  # Keep queue sizes for visualization
+    for t in range(steps):
+        if random.random() < join_chance:
+            mm.add_player(random_player(player_id, t))
+            player_id += 1
+        mm.step(t, stay_chance=stay_chance, match_duration=match_duration)
+        history.append(len(mm.queue))
+
+    queue_dist = [len([p for p in mm.queue if p.region == r]) for r in REGIONS]
+    match_regions = REGIONS + ["Cross"]
+    match_dist = [len([m for m in mm.completed_matches if m.region == r]) for r in match_regions]
+    return mm, history, queue_dist, match_dist, match_regions
+
+
+if __name__ == "__main__":
+    mm, history, qdist, mdist, _ = run_simulation()
+    print(f"Total matches: {len(mm.completed_matches)}")
+    print("Queue distribution:", dict(zip(REGIONS, qdist)))

--- a/visualize.py
+++ b/visualize.py
@@ -1,0 +1,16 @@
+import matplotlib.pyplot as plt
+from matchmaking import run_simulation
+
+
+if __name__ == "__main__":
+    _, history, _, _, _ = run_simulation(steps=200)
+
+    plt.figure(figsize=(8, 4))
+    plt.plot(history, label="Players in queue")
+    plt.xlabel("Time step")
+    plt.ylabel("Queue size")
+    plt.title("Matchmaking Queue Size Over Time")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig("queue_size.png")
+    print("Saved queue_size.png")


### PR DESCRIPTION
## Summary
- make matches temporary and optionally requeue players
- generate players with Gaussian ELO and level
- add stay chance slider in interactive demo
- document executable build instructions
- ignore build artefacts

## Testing
- `python -m py_compile matchmaking.py visualize.py interactive.py`
- `python matchmaking.py | head`
- `python visualize.py | head`
- `pyinstaller --onefile interactive.py`

------
https://chatgpt.com/codex/tasks/task_e_686f2ffcba0c832c97dda60b86dd4263